### PR TITLE
Upgrade dev-docker image for fix entrypoint bug

### DIFF
--- a/docker/dev/python/Dockerfile
+++ b/docker/dev/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-slim
+FROM python:3.6.10-slim-stretch
 MAINTAINER ckreuzberger@localhost
 
 COPY ./app /app


### PR DESCRIPTION

![Screenshot from 2020-01-14 12-29-00](https://user-images.githubusercontent.com/17265995/72337187-2d0c4680-36d3-11ea-9d29-530353fa1cdb.jpg)


The current docker image has an issue in creating a user instance when running entrypoint.sh only on dev mode.

This fixes the issue.
